### PR TITLE
Fix express json option typo

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ dotenv.config();
 
 const app = express();
 app.use(cors());
-app.use(express.json({ limig: "50mb" }))
+app.use(express.json({ limit: "50mb" }))
 
 app.use("/api/v1/dalle", dalleRoutes);
 


### PR DESCRIPTION
## Summary
- fix typo in server index.js

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` in client *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683f701ab1208330a8d53d85875c6f90